### PR TITLE
110 add georef to disparity map

### DIFF
--- a/pandora2d/common.py
+++ b/pandora2d/common.py
@@ -67,13 +67,13 @@ def save_dataset(dataset: xr.Dataset, cfg: Dict, output: str) -> None:
     mkdir_p(output)
 
     # save disp map for row
-    write_data_array(dataset["row_map"], os.path.join(output, "row_disparity.tif"), crs=dataset.attrs["crs"],transform=dataset.attrs["transform"])
+    write_data_array(dataset["row_map"], os.path.join(output, "row_disparity.tif"))
 
     # save disp map for columns
-    write_data_array(dataset["col_map"], os.path.join(output, "columns_disparity.tif"), crs=dataset.attrs["crs"],transform=dataset.attrs["transform"])
+    write_data_array(dataset["col_map"], os.path.join(output, "columns_disparity.tif"))
 
     # save correlation score
-    write_data_array(dataset["correlation_score"], os.path.join(output, "correlation_score.tif"),crs=dataset.attrs["crs"], transform=dataset.attrs["transform"])
+    write_data_array(dataset["correlation_score"], os.path.join(output, "correlation_score.tif"))
 
 
 def dataset_disp_maps(

--- a/pandora2d/common.py
+++ b/pandora2d/common.py
@@ -67,13 +67,13 @@ def save_dataset(dataset: xr.Dataset, cfg: Dict, output: str) -> None:
     mkdir_p(output)
 
     # save disp map for row
-    write_data_array(dataset["row_map"], os.path.join(output, "row_disparity.tif"))
+    write_data_array(dataset["row_map"], os.path.join(output, "row_disparity.tif"), crs=dataset.attrs["crs"],transform=dataset.attrs["transform"])
 
     # save disp map for columns
-    write_data_array(dataset["col_map"], os.path.join(output, "columns_disparity.tif"))
+    write_data_array(dataset["col_map"], os.path.join(output, "columns_disparity.tif"), crs=dataset.attrs["crs"],transform=dataset.attrs["transform"])
 
     # save correlation score
-    write_data_array(dataset["correlation_score"], os.path.join(output, "correlation_score.tif"))
+    write_data_array(dataset["correlation_score"], os.path.join(output, "correlation_score.tif"),crs=dataset.attrs["crs"], transform=dataset.attrs["transform"])
 
 
 def dataset_disp_maps(

--- a/pandora2d/common.py
+++ b/pandora2d/common.py
@@ -67,13 +67,13 @@ def save_dataset(dataset: xr.Dataset, cfg: Dict, output: str) -> None:
     mkdir_p(output)
 
     # save disp map for row
-    write_data_array(dataset["row_map"], os.path.join(output, "row_disparity.tif"))
+    write_data_array(dataset["row_map"], os.path.join(output, "row_disparity.tif"),crs=dataset.attrs["crs"], transform=dataset.attrs["transform"])
 
     # save disp map for columns
-    write_data_array(dataset["col_map"], os.path.join(output, "columns_disparity.tif"))
+    write_data_array(dataset["col_map"], os.path.join(output, "columns_disparity.tif"),crs=dataset.attrs["crs"], transform=dataset.attrs["transform"])
 
     # save correlation score
-    write_data_array(dataset["correlation_score"], os.path.join(output, "correlation_score.tif"))
+    write_data_array(dataset["correlation_score"], os.path.join(output, "correlation_score.tif"),crs=dataset.attrs["crs"], transform=dataset.attrs["transform"])
 
 
 def dataset_disp_maps(

--- a/pandora2d/state_machine.py
+++ b/pandora2d/state_machine.py
@@ -404,7 +404,7 @@ class Pandora2DMachine(Machine):  # pylint:disable=too-many-instance-attributes
             map_col,
             self.cost_volumes.coords,
             correlation_score,
-            {"invalid_disp": cfg["pipeline"]["disparity"]["invalid_disparity"],"crs":self.left_img.crs,"transform":self.left_img.transform},
+            {"invalid_disp": cfg["pipeline"]["disparity"]["invalid_disparity"]},
         )
 
     def refinement_run(self, cfg: Dict[str, dict], input_step: str) -> None:

--- a/pandora2d/state_machine.py
+++ b/pandora2d/state_machine.py
@@ -404,7 +404,7 @@ class Pandora2DMachine(Machine):  # pylint:disable=too-many-instance-attributes
             map_col,
             self.cost_volumes.coords,
             correlation_score,
-            {"invalid_disp": cfg["pipeline"]["disparity"]["invalid_disparity"]},
+            {"invalid_disp": cfg["pipeline"]["disparity"]["invalid_disparity"],"crs":self.left_img.crs,"transform":self.left_img.transform}
         )
 
     def refinement_run(self, cfg: Dict[str, dict], input_step: str) -> None:

--- a/pandora2d/state_machine.py
+++ b/pandora2d/state_machine.py
@@ -404,7 +404,7 @@ class Pandora2DMachine(Machine):  # pylint:disable=too-many-instance-attributes
             map_col,
             self.cost_volumes.coords,
             correlation_score,
-            {"invalid_disp": cfg["pipeline"]["disparity"]["invalid_disparity"]},
+            {"invalid_disp": cfg["pipeline"]["disparity"]["invalid_disparity"],"crs":self.left_img.crs,"transform":self.left_img.transform},
         )
 
     def refinement_run(self, cfg: Dict[str, dict], input_step: str) -> None:


### PR DESCRIPTION
Modifications to add georeferencing to output disparity maps.

First I added the georeferencing attributes to the disparity map dataset  in the state_machin.py file. 
Next, in the common.py file, the transform and associated crs are filled when writing the files.