### PR TITLE
115 config phase cross correlation

### DIFF
--- a/docs/source/userguide/step_by_step/estimation.rst
+++ b/docs/source/userguide/step_by_step/estimation.rst
@@ -49,20 +49,20 @@ Configuration and parameters
       - Exploration around the initial disparity for columns
       - int
       - 5
-      - >0, odd number
+      - >2, odd number
       - No
     * - *range_row*
       - Exploration around the initial disparity for rows
       - int
       - 5
-      - >0, odd number
+      - >2, odd number
       - No
     * - *sample_factor*
       - | Upsampling factor.
         | Images will be registered to within 1 / upsample_factor of a pixel
       - int
       - 1
-      - >= 1
+      - >= 1, multiple of 10
       - No
 
 

--- a/pandora2d/estimation/phase_cross_correlation.py
+++ b/pandora2d/estimation/phase_cross_correlation.py
@@ -84,8 +84,8 @@ class PhaseCrossCorrelation(estimation.AbstractEstimation):
         # Estimation schema config
         schema = {
             "estimation_method": And(str, lambda estimation_method: estimation_method in ["phase_cross_correlation"]),
-            "range_col": And(int, lambda range_col: range_col % 2 and range_col > 2),
-            "range_row": And(int, lambda range_row: range_row % 2 and range_row > 2),
+            "range_row": And(int, lambda range_row: range_row > 2, lambda range_row: range_row % 2 != 0),
+            "range_col": And(int, lambda range_col: range_col > 2, lambda range_col: range_col % 2 != 0),
             "sample_factor": And(int, lambda sf: sf % 10 == 0 or sf == 1, lambda sf: sf > 0),
         }
 


### PR DESCRIPTION
Changes have been made to the checker during estimation step.  The "range_col" and "range_row" values must be odd and greater than 2.

These changes are indicated in the documentation by modifying the parameters and also the "sample_factor" parameter, which must be a multiple of 10 (already checked in the checker but not indicated).